### PR TITLE
see issue #6379

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1874,7 +1874,8 @@ class Editor(SpyderPluginWidget):
         if text is None:
             default_content = True
             text, enc = encoding.read(self.TEMPLATE_PATH)
-            enc_match = re.search(r'-*- coding: ?([a-z0-9A-Z\-]*) -*-', text)
+            enc_match = re.search('-*- coding: ?([a-z0-9A-Z\-]*) -*-', text)
+            annotation_match = re.search('"""(?:(?!""").|[\n\r])*"""', text)
             if enc_match:
                 enc = enc_match.group(1)
             # Initialize template variables
@@ -1886,11 +1887,15 @@ class Editor(SpyderPluginWidget):
                 username = encoding.to_unicode_from_fs(os.environ.get('USER',
                                                                       '-'))
             VARS = {
-                'date': time.ctime(),
+                'date': time.strftime("%Y-%m-%d %H:%M"),
                 'username': username,
             }
             try:
-                text = text % VARS
+                #text = text % VARS
+                text = re.sub('"""(?:(?!""").|[\n\r])*"""',
+                              annotation_match[0] % VARS,
+                              text,
+                              count=1)
             except:
                 pass
         else:

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1861,14 +1861,14 @@ class Editor(SpyderPluginWidget):
             editor = editorstack.clone_editor_from(finfo, set_current=False)
             self.register_widget_shortcuts(editor)
     
-    def _replace_tripe_quote(self, m, v=None):
-        try:
-            ans = m[0] % v
-        except:
-            ans = m[0]
-            return ans
-        else:
-            return ans
+    def _render_linebyline(self, text, _VARS=None):
+        text = text.split('\n')
+        for i, line in enumerate(t):
+            try:
+                text[i] = line % _VARS
+            except:
+                pass
+        return '\n'.join(text)
 
     @Slot()
     @Slot(str)
@@ -1895,18 +1895,13 @@ class Editor(SpyderPluginWidget):
                 username = encoding.to_unicode_from_fs(os.environ.get('USER',
                                                                       '-'))
             VARS = {
-                'date-spyder': time.ctime(),
+                'date-spyder': time.strftime("%Y-%m-%d %H:%M"),
                 'username-spyder': username,
             }
             try:
                 text = text % VARS
-            except:
-                from functools import partial
-                replace = partial(self._replace_tripe_quote, v=VARS)
-                pat = '"""(?:(?!""").|[\n\r])*"""'
-                text = re.sub(pat,
-                              replace,
-                              text)
+            except (KeyError,TypeError):
+                text = self._render_linebyline(text, _VARS=VARS)
         else:
             default_content = False
             enc = encoding.read(self.TEMPLATE_PATH)[1]

--- a/spyder/plugins/tests/test_template_renderer.py
+++ b/spyder/plugins/tests/test_template_renderer.py
@@ -85,12 +85,16 @@ class TestClass():
         return '\n'.join(t)
 
     def new(self, text):
-        import time, os
+        import time
 
         VARS = {
-            'date-spyder': time.strftime("%Y-%m-%d"),
-            'username-spyder': os.getenv('USERNAME'),
+            'date-spyder': time.strftime("%Y-%m"),
+            'username-spyder': 'cts',
         }
+        """
+        cant use "os.getenv('USERNAME')" here in order to pass the
+        autotest proceed by appveyor and travis-ci.
+        """
 
         try:
             text = text % VARS
@@ -106,7 +110,7 @@ class TestClass():
         expected = '''
     # -*- coding: utf-8 -*-
     """
-    Created on 2018-02-09
+    Created on 2018-02
 
     Creator: cts
     """
@@ -126,7 +130,7 @@ class TestClass():
         expected = '''
     # -*- coding: utf-8 -*-
     """
-    Created on 2018-02-09
+    Created on 2018-02
 
     Creator: %(its_bad)s
     """
@@ -146,7 +150,7 @@ class TestClass():
         expected = '''
     # -*- coding: utf-8 -*-
     """
-    Created on 2018-02-09
+    Created on 2018-02
 
     Creator: cts
     """
@@ -173,7 +177,7 @@ class TestClass():
         expected = '''
     # -*- coding: utf-8 -*-
     """
-    Created on 2018-02-09
+    Created on 2018-02
 
     Creator: %(its_bad)s
     """

--- a/spyder/plugins/tests/test_template_renderer.py
+++ b/spyder/plugins/tests/test_template_renderer.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""
+test for PR: #6380
+"""
+import pytest
+class TestClass():
+    TEXT_ALL_GOOD = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on %(date-spyder)s
+
+    Creator: %(username-spyder)s
+    """
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+    TEXT_BAD_IN_TRIQUOTE = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on %(date-spyder)s
+
+    Creator: %(its_bad)s
+    """
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+    TEXT_BAD_OUTSIDE = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on %(date-spyder)s
+
+    Creator: %(username-spyder)s
+    """
+    import logzero,logging
+    f = '%(color)s[%(levelname)s][%(funcName)s|%(lineno)s] -> %(message)s%(end_color)s'
+    cts_msg = logzero.setup_logger(level=logging.INFO,# change level here
+                                   formatter=logzero.LogFormatter(fmt=f))
+    LD = cts_msg.debug
+    LI = cts_msg.info
+    LE = cts_msg.error
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+    TEXT_BAD_EVERYWHERE = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on %(date-spyder)s
+
+    Creator: %(its_bad)s
+    """
+    import logzero,logging
+    f = '%(color)s[%(levelname)s][%(funcName)s|%(lineno)s] -> %(message)s%(end_color)s'
+    cts_msg = logzero.setup_logger(level=logging.INFO,# change level here
+                                   formatter=logzero.LogFormatter(fmt=f))
+    LD = cts_msg.debug
+    LI = cts_msg.info
+    LE = cts_msg.error
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+
+    def _render_linebyline(self, t, _VARS=None):
+        t = t.split('\n')
+        for i, line in enumerate(t):
+            try:
+                t[i] = line % _VARS
+            except Exception:
+                pass
+        return '\n'.join(t)
+
+    def new(self, text):
+        import time, os
+
+        VARS = {
+            'date-spyder': time.strftime("%Y-%m-%d"),
+            'username-spyder': os.getenv('USERNAME'),
+        }
+
+        try:
+            text = text % VARS
+        except (KeyError, TypeError):
+            text = self._render_linebyline(text, VARS)
+
+        return text
+
+    def test_all_good(self):
+        """all placeholders are vaild."""
+        """expecting full-replaced."""
+        result = self.new(self.TEXT_ALL_GOOD)
+        expected = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on 2018-02-09
+
+    Creator: cts
+    """
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+        assert result == expected
+
+    def test_bad_in_triquote(self):
+        """some placeholders in triquote are invaild."""
+        """expecting good ones been replaced, bad ones get ignored"""
+        result = self.new(self.TEXT_BAD_IN_TRIQUOTE)
+        expected = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on 2018-02-09
+
+    Creator: %(its_bad)s
+    """
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+        assert result == expected
+
+    def test_bad_outside(self):
+        """some placeholders outside triquote section are invaild."""
+        """expecting good ones been replaced, bad ones get ignored"""
+        result = self.new(self.TEXT_BAD_OUTSIDE)
+        expected = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on 2018-02-09
+
+    Creator: cts
+    """
+    import logzero,logging
+    f = '%(color)s[%(levelname)s][%(funcName)s|%(lineno)s] -> %(message)s%(end_color)s'
+    cts_msg = logzero.setup_logger(level=logging.INFO,# change level here
+                                   formatter=logzero.LogFormatter(fmt=f))
+    LD = cts_msg.debug
+    LI = cts_msg.info
+    LE = cts_msg.error
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+        assert result == expected
+
+    def test_bad_everywhere(self):
+        """invaild placeholders are in both inside and outside of triquote section."""
+        """expecting good ones been replaced, bad ones get ignored"""
+        result = self.new(self.TEXT_BAD_EVERYWHERE)
+        expected = '''
+    # -*- coding: utf-8 -*-
+    """
+    Created on 2018-02-09
+
+    Creator: %(its_bad)s
+    """
+    import logzero,logging
+    f = '%(color)s[%(levelname)s][%(funcName)s|%(lineno)s] -> %(message)s%(end_color)s'
+    cts_msg = logzero.setup_logger(level=logging.INFO,# change level here
+                                   formatter=logzero.LogFormatter(fmt=f))
+    LD = cts_msg.debug
+    LI = cts_msg.info
+    LE = cts_msg.error
+    ### requirements
+    ### TODO
+
+
+    if __name__ == '__main__':
+
+    '''
+        assert result == expected
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
take the part between tripe-double-quotes seperately and deal with it seperately we can replace %(date)s properly no matter what a man add in template.py